### PR TITLE
use isBrowserGivenByCli only for run mode

### DIFF
--- a/packages/data-context/src/data/ProjectLifecycleManager.ts
+++ b/packages/data-context/src/data/ProjectLifecycleManager.ts
@@ -315,14 +315,14 @@ export class ProjectLifecycleManager {
   async setInitialActiveBrowser () {
     const configBrowser = this.loadedFullConfig?.defaultBrowser
 
-    if (configBrowser && !this.ctx.modeOptions.isBrowserGivenByCli) {
-      if (this.ctx.isRunMode) {
+    if (configBrowser) {
+      if (this.ctx.isRunMode && !this.ctx.modeOptions.isBrowserGivenByCli) {
         this.ctx.setModeOptionsBrowser(configBrowser)
 
         return
       }
 
-      this.ctx.coreData.cliBrowser = configBrowser
+      this.ctx.coreData.cliBrowser ??= configBrowser
     }
 
     if (this.ctx.coreData.cliBrowser) {

--- a/packages/server/lib/modes/index.ts
+++ b/packages/server/lib/modes/index.ts
@@ -10,8 +10,6 @@ export = (mode, options) => {
     return require('./smoke_test').run(options)
   }
 
-  options.isBrowserGivenByCli = options.browser !== undefined
-
   if (mode === 'run') {
     _.defaults(options, {
       socketId: random.id(10),
@@ -20,6 +18,7 @@ export = (mode, options) => {
       quiet: false,
       morgan: false,
       report: true,
+      isBrowserGivenByCli: options.browser !== undefined,
     })
   }
 

--- a/packages/types/src/modeOptions.ts
+++ b/packages/types/src/modeOptions.ts
@@ -1,7 +1,6 @@
 export interface CommonModeOptions {
   _?: (string | null)[] | null
   invokedFromCli: boolean
-  isBrowserGivenByCli: boolean
   userNodePath?: string
   userNodeVersion?: string
   configFile?: string | null
@@ -25,6 +24,7 @@ export interface RunModeOptions extends CommonModeOptions {
   parallel?: boolean | null
   ciBuildId?: string | null
   tag?: (string)[] | null
+  isBrowserGivenByCli: boolean
 }
 
 export type TestingType = 'e2e' | 'component'


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
